### PR TITLE
Fix accessibility issues in the document markup of fylo-data-storage-component challenge

### DIFF
--- a/fylo-data-storage-component/index.html
+++ b/fylo-data-storage-component/index.html
@@ -25,31 +25,30 @@
     <main class="challenge-container">
       <div class="wrapper">
         <div class="hero">
-          <h1 aria-label="Fylo">
-            <img src="./images/logo.svg" alt="Fylo logo" class="hero__title" />
-          </h1>
+          <h1 style="display: none">Fylo</h1>
+          <img src="./images/logo.svg" alt="Fylo logo" class="hero__title" />
           <div class="btn">
-            <button class="btn__document">
+            <div class="btn__document" role="button">
               <img
                 src="./images/icon-document.svg"
                 alt="Document"
                 aria-hidden="true"
               />
-            </button>
-            <button class="btn__folder">
+            </div>
+            <div class="btn__folder" role="button">
               <img
                 src="./images/icon-folder.svg"
                 alt="Folder"
                 aria-hidden="true"
               />
-            </button>
-            <button class="btn__upload">
+            </div>
+            <div class="btn__upload" role="button">
               <img
                 src="./images/icon-upload.svg"
                 alt="Upload"
                 aria-hidden="true"
               />
-            </button>
+            </div>
           </div>
         </div>
         <div class="usage">

--- a/fylo-data-storage-component/index.html
+++ b/fylo-data-storage-component/index.html
@@ -28,21 +28,21 @@
           <h1 style="display: none">Fylo</h1>
           <img src="./images/logo.svg" alt="Fylo logo" class="hero__title" />
           <div class="btn">
-            <div class="btn__document" role="button">
+            <div class="btn__document" role="button" tabindex="0">
               <img
                 src="./images/icon-document.svg"
                 alt="Document"
                 aria-hidden="true"
               />
             </div>
-            <div class="btn__folder" role="button">
+            <div class="btn__folder" role="button" tabindex="0">
               <img
                 src="./images/icon-folder.svg"
                 alt="Folder"
                 aria-hidden="true"
               />
             </div>
-            <div class="btn__upload" role="button">
+            <div class="btn__upload" role="button" tabindex="0">
               <img
                 src="./images/icon-upload.svg"
                 alt="Upload"

--- a/fylo-data-storage-component/style.css
+++ b/fylo-data-storage-component/style.css
@@ -50,7 +50,7 @@ body {
   gap: 1em;
 }
 
-button[class^="btn__"] {
+div[class^="btn__"] {
   all: unset;
   display: flex;
   justify-content: center;
@@ -62,7 +62,7 @@ button[class^="btn__"] {
   background-color: var(--clr-very-dark-blue);
   cursor: pointer;
 }
-button[class^="btn__"]:is(:hover, :focus) {
+div[class^="btn__"]:is(:hover, :focus) {
   outline: 1px solid var(--clr-pale-blue);
   scale: 1.1;
   opacity: 0.75;


### PR DESCRIPTION
Pull request corresponding to [Fylo data storage component](https://www.frontendmentor.io/challenges/fylo-data-storage-component-1dZPRbV5n) challenge from [Frontend Mentor](https://www.frontendmentor.io/)

- [ ] New solution
- [x] Fix issues found in the [accessibility report](https://www.frontendmentor.io/solutions/mobilefirst-solution-using-flexbox-qo_mdI1nUy)
- [ ] Implement feedback [comments]() from [@commenter](https://www.frontendmentor.io/profile/commenter_username)

Issue summary:

1. Page should contain a level-one heading
    - Fixed by adding an `<h1>` element enclosing the heading text and styling it with `display: none`
1. Buttons must have discernible text
    - Fixed by changing `<button>` to `<div>` and adding `role="button"` in the markup
